### PR TITLE
handle pods without volumes

### DIFF
--- a/platform_disk_api/kube_client.py
+++ b/platform_disk_api/kube_client.py
@@ -167,7 +167,7 @@ class PodRead:
     @classmethod
     def from_primitive(cls, payload: dict[str, Any]) -> "PodRead":
         pvc_names = []
-        for volume in payload["spec"]["volumes"]:
+        for volume in payload["spec"].get("volumes", []):
             pvc_data = volume.get("persistentVolumeClaim")
             if pvc_data:
                 pvc_names.append(pvc_data["claimName"])

--- a/tests/unit/test_pods.py
+++ b/tests/unit/test_pods.py
@@ -7,7 +7,7 @@ from platform_disk_api.kube_client import PodListResult, PodRead, PodWatchEvent
 
 class TestPodSerialization:
     def _make_pod_payload(self, pvc_names: list[str]) -> dict[str, Any]:
-        return {
+        result: dict[str, Any] = {
             "kind": "Pod",
             "apiVersion": "v1",
             "metadata": {"name": "boo"},
@@ -20,14 +20,16 @@ class TestPodSerialization:
                         "command": ["sh", "-c", "sleep 1"],
                     }
                 ],
-                "volumes": [
-                    {"name": f"disk-{i}", "persistentVolumeClaim": {"claimName": name}}
-                    for (i, name) in enumerate(pvc_names)
-                ],
             },
         }
+        if pvc_names:
+            result["spec"]["volumes"] = [
+                {"name": f"disk-{i}", "persistentVolumeClaim": {"claimName": name}}
+                for (i, name) in enumerate(pvc_names)
+            ]
+        return result
 
-    @pytest.mark.parametrize("pvc_names", [("pvc1", "pvc2", "pvc3")])
+    @pytest.mark.parametrize("pvc_names", [(), ("pvc1", "pvc2", "pvc3")])
     def test_pod_from_primitive(
         self,
         pvc_names: list[str],


### PR DESCRIPTION
Found error spikes in Google Cloud Logs which significantly increase Cloud Logging costs.
```
  File "/root/.local/lib/python3.9/site-packages/platform_disk_api/usage_watcher.py", line 43, in watch_disk_usage
    list_result = await kube_client.list_pods()
  File "/root/.local/lib/python3.9/site-packages/platform_disk_api/kube_client.py", line 480, in list_pods
    return PodListResult.from_primitive(payload)
  File "/root/.local/lib/python3.9/site-packages/platform_disk_api/kube_client.py", line 186, in from_primitive
    pods=[PodRead.from_primitive(item) for item in payload["items"]],
  File "/root/.local/lib/python3.9/site-packages/platform_disk_api/kube_client.py", line 186, in <listcomp>
    pods=[PodRead.from_primitive(item) for item in payload["items"]],
  File "/root/.local/lib/python3.9/site-packages/platform_disk_api/kube_client.py", line 170, in from_primitive
    for volume in payload["spec"]["volumes"]:
KeyError: 'volumes'
```