### PR TITLE
support unique naming within project, support no org filtering

### DIFF
--- a/platform_disk_api/api.py
+++ b/platform_disk_api/api.py
@@ -184,7 +184,7 @@ class DiskApiHandler:
                 org_name = None
                 project_name = owner
             if not project_name:
-                raise ValueError("project_name is required to search disk by name")
+                raise ValueError("project_name is required to search for disk by name")
             try:
                 disk = await self._service.get_disk_by_name(
                     id_or_name, org_name, project_name

--- a/tests/integration/test_service.py
+++ b/tests/integration/test_service.py
@@ -80,7 +80,20 @@ class TestService:
             storage=1024 * 1024, name="test-name", project_name="test-project"
         )
         disk_created = await service.create_disk(request, "testuser")
-        disk_get = await service.get_disk_by_name("test-name", "testuser")
+        disk_get = await service.get_disk_by_name("test-name", None, "test-project")
+        assert disk_get.id == disk_created.id
+        assert disk_get.owner == disk_created.owner
+        assert disk_get.storage >= disk_created.storage
+
+    async def test_get_disk_by_name__if_owner_and_project_name_same(
+        self, service: Service
+    ) -> None:
+        request = DiskRequest(
+            storage=1024 * 1024, name="test-name", project_name="testuser"
+        )
+        disk_created = await service.create_disk(request, "testuser")
+
+        disk_get = await service.get_disk_by_name("test-name", "any", "testuser")
         assert disk_get.id == disk_created.id
         assert disk_get.owner == disk_created.owner
         assert disk_get.storage >= disk_created.storage


### PR DESCRIPTION
Following issues fixed:
* there is no way to create disks with same name in different projects by the same user.
* there is no way to filter legacy disks in get all API endpoint