### PR TITLE
IT-126: bump apolo-kube-client to 25.12.2 (ingress-gateway netpol fix)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -315,14 +315,14 @@ pytest = ["pytest (>=8.4.1)", "pytest-aiohttp (>=1.1.0)", "pytest-asyncio (>=1.0
 
 [[package]]
 name = "apolo-kube-client"
-version = "25.12.1"
+version = "25.12.2"
 description = "Apolo internal client for kubernetes API"
 optional = false
 python-versions = "<4.0,>=3.13"
 groups = ["main"]
 files = [
-    {file = "apolo_kube_client-25.12.1-py3-none-any.whl", hash = "sha256:7fde674055bd9695919413cf834a81f632f4850675d840ba59ad67dbb2eb6bca"},
-    {file = "apolo_kube_client-25.12.1.tar.gz", hash = "sha256:55e798eeacc0f80dd70c1928b625a8678f0b3faf4df47332120f61f6e2cd0ef0"},
+    {file = "apolo_kube_client-25.12.2-py3-none-any.whl", hash = "sha256:a8a852b2f04051851c1e83cbe275213b26e784401a3a59c113bfe8384e4fe484"},
+    {file = "apolo_kube_client-25.12.2.tar.gz", hash = "sha256:4c11bbc4d87e26d7972c74a3e9cc3ecfbd99d3dd4cfd8eec4e7855cc9de6a5f5"},
 ]
 
 [package.dependencies]
@@ -2839,4 +2839,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<4.0"
-content-hash = "238a3706ec28ccbc335fabb4a434b8e87c39e574a7857e99afd31a2d34727f6f"
+content-hash = "987a2ffc84790dfdf1d78098c26abfa284d4348b381007b22cd17f71a33709ed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ aiohttp-cors = "0.8.1"
 uvloop = "^0.22.1"
 pydantic = "^2.12.5"
 apolo-events-client = ">=25.10,<27.0"
-apolo-kube-client = "^25.12.1"
+apolo-kube-client = "^25.12.2"
 
 [tool.poetry.scripts]
 platform-disk-api = "platform_disk_api.api:main"


### PR DESCRIPTION
Bumps apolo-kube-client to **25.12.2** — updates both the pyproject constraint and the lock, to explicitly require the fix.

25.12.2 fixes the per-project egress NetworkPolicy: the ingress-gateway rule’s `namespaceSelector` was an empty `V1LabelSelector()` dropped on serialization, leaving it podSelector-only (same-namespace) so project pods could not reach traefik in `platform`. This service creates/touches project namespaces + this netpol via `KubeClientSelector.get_client(ensure_namespace=True)`, so shipping this propagates the fix on next access.

Paired with cloud-infra #491 (traefik ingress-gateway label). Ref: IT-126.